### PR TITLE
Add policymaker briefing page at /briefing/

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -14,5 +14,7 @@ resources:
     - label: Past Plenaries (YouTube)
       url: https://www.youtube.com/@hackersonthehill
       external: true
+    - label: Policymaker Briefing
+      url: /briefing/
     - label: Style Guide
       url: /style-guide/

--- a/_layouts/briefing.html
+++ b/_layouts/briefing.html
@@ -1,0 +1,7 @@
+---
+layout: base
+---
+
+<div class="briefing-main">
+  {{ content }}
+</div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1888,6 +1888,194 @@ button.location-card {
 }
 
 /*--------------------------------------------------------------
+# 9.15 Briefing Page
+--------------------------------------------------------------*/
+.briefing-main {
+  padding-top: 96px;
+}
+
+.briefing-hero {
+  background-color: var(--bg-secondary);
+  padding: 72px 0 40px;
+}
+
+.briefing-hero h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
+}
+
+.briefing-tagline {
+  color: var(--accent-primary);
+  font-weight: 600;
+  font-size: 1.15rem;
+  margin-bottom: 0;
+}
+
+.briefing-section {
+  padding: 48px 0 64px;
+}
+
+.briefing-section h2 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-top: 40px;
+  margin-bottom: 16px;
+  color: var(--text-primary);
+}
+
+.briefing-section p {
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+  line-height: 1.7;
+}
+
+.briefing-lede {
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.briefing-impact-strip {
+  background: var(--bg-secondary);
+  border-left: 4px solid var(--accent-primary);
+  border-radius: 0 12px 12px 0;
+  padding: 20px 24px;
+  margin: 28px 0;
+}
+
+.briefing-impact-strip .briefing-impact-label {
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent-primary);
+  margin-bottom: 6px;
+}
+
+.briefing-impact-strip p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-bottom: 0;
+  color: var(--text-primary);
+}
+
+.briefing-pullquote {
+  border-left: 4px solid var(--accent-primary);
+  padding: 16px 24px;
+  margin: 28px 0;
+  background: transparent;
+}
+
+.briefing-pullquote p {
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--text-secondary);
+  margin-bottom: 0;
+  line-height: 1.65;
+}
+
+.briefing-table-wrap {
+  margin: 20px 0 32px;
+  overflow-x: auto;
+}
+
+.briefing-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.briefing-table thead {
+  border-bottom: 2px solid var(--accent-primary);
+}
+
+.briefing-table th {
+  font-weight: 600;
+  text-align: left;
+  padding: 10px 14px;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.briefing-table td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-accent);
+  color: var(--text-primary);
+  vertical-align: top;
+}
+
+.briefing-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.briefing-contact {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 28px 0 20px;
+  text-align: center;
+}
+
+.briefing-contact p {
+  margin-bottom: 0;
+  font-size: 0.95rem;
+}
+
+.briefing-cavalry-motto {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 8px;
+}
+
+.briefing-rule {
+  border: none;
+  border-top: 1px solid var(--border-accent);
+  margin: 24px 0 16px;
+}
+
+.briefing-footnotes {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.briefing-footnotes p {
+  margin-bottom: 0;
+}
+
+@media (max-width: 575px) {
+  .briefing-main {
+    padding-top: 80px;
+  }
+
+  .briefing-hero {
+    padding: 64px 0 32px;
+  }
+
+  .briefing-hero h1 {
+    font-size: 1.75rem;
+  }
+
+  .briefing-section {
+    padding: 32px 0 48px;
+  }
+
+  .briefing-impact-strip {
+    padding: 16px 18px;
+  }
+
+  .briefing-table th,
+  .briefing-table td {
+    padding: 8px 10px;
+    font-size: 0.82rem;
+  }
+}
+
+/*--------------------------------------------------------------
 # 9.2 Print Styles
 --------------------------------------------------------------*/
 @media print {
@@ -1898,19 +2086,147 @@ button.location-card {
   .theme-toggle {
     display: none !important;
   }
-  
+
   body {
     background: white;
     color: black;
   }
-  
+
   a {
     color: black;
     text-decoration: underline;
   }
-  
+
   .location-card {
     page-break-inside: avoid;
+  }
+
+  /* Briefing page print optimization */
+  .briefing-main {
+    padding-top: 0;
+  }
+
+  .briefing-hero {
+    background: none;
+    padding: 0 0 8px;
+    border-bottom: 3px solid #6b46a3;
+    margin-bottom: 16px;
+  }
+
+  .briefing-hero h1 {
+    font-size: 1.75rem;
+    margin-bottom: 2px;
+  }
+
+  .briefing-tagline {
+    color: #6b46a3;
+    font-size: 1rem;
+  }
+
+  .briefing-section {
+    padding: 0;
+  }
+
+  .briefing-section h2 {
+    margin-top: 20px;
+    margin-bottom: 8px;
+    font-size: 1.15rem;
+    color: #6b46a3;
+  }
+
+  .briefing-section p {
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin-bottom: 8px;
+  }
+
+  .briefing-lede {
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+
+  .briefing-impact-strip {
+    border-left: 3px solid #6b46a3;
+    padding: 10px 14px;
+    margin: 12px 0;
+    background: #f5f5f5;
+    page-break-inside: avoid;
+  }
+
+  .briefing-impact-strip .briefing-impact-label {
+    color: #6b46a3;
+    font-size: 0.75rem;
+    margin-bottom: 4px;
+  }
+
+  .briefing-impact-strip p {
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+
+  .briefing-pullquote {
+    border-left: 3px solid #6b46a3;
+    padding: 8px 14px;
+    margin: 12px 0;
+    page-break-inside: avoid;
+  }
+
+  .briefing-pullquote p {
+    font-size: 0.85rem;
+    color: #555;
+    line-height: 1.5;
+  }
+
+  .briefing-table-wrap {
+    margin: 10px 0 16px;
+    page-break-inside: avoid;
+  }
+
+  .briefing-table {
+    font-size: 0.78rem;
+  }
+
+  .briefing-table thead {
+    border-bottom: 2px solid #6b46a3;
+  }
+
+  .briefing-table th {
+    padding: 6px 8px;
+    font-size: 0.78rem;
+  }
+
+  .briefing-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .briefing-contact {
+    background: #f5f5f5;
+    padding: 12px 16px;
+    margin: 14px 0 10px;
+    page-break-inside: avoid;
+  }
+
+  .briefing-contact p {
+    font-size: 0.85rem;
+  }
+
+  .briefing-cavalry-motto {
+    font-size: 0.85rem;
+    margin-bottom: 4px;
+  }
+
+  .briefing-rule {
+    margin: 12px 0 8px;
+  }
+
+  .briefing-footnotes {
+    font-size: 0.72rem;
+    line-height: 1.4;
+  }
+
+  #footer {
+    display: none !important;
   }
 }
 

--- a/briefing.md
+++ b/briefing.md
@@ -1,0 +1,154 @@
+---
+title: Hackers on the Hill — Policymaker Briefing
+layout: briefing
+permalink: /briefing/
+---
+
+<section class="briefing-hero">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
+        <h1>Hackers on the Hill</h1>
+        <p class="briefing-tagline">Technical Truth Meets Policy Power</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
+
+<p class="briefing-lede"><strong>Effective policy depends on foresight</strong> to understand emerging risks and
+opportunities before they arrive as crises. Your offices hear regularly from
+industry, academia, and think tanks, and each brings real value. Hackers on the
+Hill brings a voice that's harder to find: the early adopters who explore new
+technology firsthand, ask the questions others don't, and anticipate consequences
+(positive and negative) before they scale. No commercial agenda. No talking
+points. Just candid conversation.</p>
+
+<p>Since 2017, Hackers on the Hill, an all-volunteer initiative, has been building
+trusted spaces where security researchers and policymakers work together on shared
+challenges. We forge relationships, hold events, and facilitate ongoing
+dialogue&nbsp;&mdash; grounded in shared values. No one gets paid. We just think policy works
+better when the people making it have candid conversations with the people
+living it.</p>
+
+<div class="briefing-impact-strip">
+  <div class="briefing-impact-label">Since 2017</div>
+  <p>Events on Capitol Hill, at the White House, and in Ottawa, London, and
+  Colorado · Hundreds of researchers engaged · Dozens of policy briefings
+  delivered · Topics include AI, ransomware, critical infrastructure, medical
+  devices, IoT, encryption, supply chain security, and vulnerability
+  disclosure · <strong>Global since 2024</strong></p>
+</div>
+
+<h2>Wait&hellip; Hackers?</h2>
+
+<p>The word carries baggage. But in the security community, a hacker is someone
+driven to understand how things work&nbsp;&mdash; and to make them work better. Think of the
+kid who took apart the family radio, the mechanic who challenges herself to
+diagnose an engine by sound, the engineer reporting cracks in the bridge their
+family drives across, or the tinkerer innovating novel uses for technology that
+aren't available on the market. Creativity, curiosity, dedication to a craft, and
+concern for others are cornerstones of <em>our</em> hacker community the same way they are
+of your local one.</p>
+
+<p>Academics study these problems, think tanks write about them, and industry sells.
+Hackers are driven to get their hands on technologies early and tend to spot
+issues and opportunities early&nbsp;&mdash; and prototype ways to address them. Hackers are
+leading indicators that give savvy policymakers a head start to shape technology
+toward the best outcomes for society.</p>
+
+<blockquote class="briefing-pullquote">
+  <p>&ldquo;Effective policy is shaped by people who foresee consequences&nbsp;&mdash; positive and
+  negative&nbsp;&mdash; firsthand. Not through reports, but with direct evidence.&rdquo;</p>
+</blockquote>
+
+<p>Security researchers are driven by a mix of motivations&nbsp;&mdash; protecting people,
+solving puzzles, professional pride, earning a living, or standing up for a
+cause.<sup><a href="#fn1" id="fnref1">1</a></sup> But the researchers who show up to engage with policymakers are
+overwhelmingly driven to <em>protect</em>&nbsp;&mdash; and they're giving their time to help you get
+it right. These are the people who found that insulin pumps could be remotely
+manipulated, that vehicle braking systems could be controlled through the
+entertainment console, and that water treatment systems were exposed to the open
+internet. In each case, they disclosed what they found in good faith so it could
+be fixed.</p>
+
+<h2>Why this matters for your office</h2>
+
+<p>Effective cybersecurity policy requires understanding the technical reality on the
+ground&nbsp;&mdash; not just position papers and industry testimony. Security researchers see
+the actual attack surface. They know which systems are fragile, where the real
+risks are, and what's already being exploited. That's the kind of practical
+intelligence that makes the difference between legislation that looks good on
+paper and legislation that actually works.</p>
+
+<p>The security research community's engagement with policymakers has already
+contributed to real outcomes:</p>
+
+<div class="briefing-table-wrap">
+<table class="briefing-table">
+  <thead>
+    <tr>
+      <th>Policy outcome</th>
+      <th>Where</th>
+      <th>Researcher role</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>PATCH Act</td>
+      <td>US</td>
+      <td>Researcher findings on medical device flaws built the case for FDA cybersecurity authority</td>
+    </tr>
+    <tr>
+      <td>California SB-327</td>
+      <td>California</td>
+      <td>Researcher demonstrations of IoT risks informed the first state law requiring connected device security</td>
+    </tr>
+    <tr>
+      <td>UK CoP &rarr; ETSI EN 303 645</td>
+      <td>UK / Global</td>
+      <td>Community input shaped a voluntary code that became the global baseline standard for IoT security</td>
+    </tr>
+    <tr>
+      <td>National Cybersecurity Strategy</td>
+      <td>US</td>
+      <td>Researchers joined White House working sessions shaping vulnerability disclosure policy</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<h2>Work with us</h2>
+
+<p>Hackers on the Hill isn't a one-day event&nbsp;&mdash; it's the start of a relationship.
+After each gathering, we facilitate follow-up conversations, technical reviews of
+draft legislation, and direct connections to subject-matter experts when your
+office needs them.</p>
+
+<p>If you're working on cybersecurity policy&nbsp;&mdash; healthcare, critical infrastructure,
+AI, defense, consumer protection&nbsp;&mdash; we can connect you with researchers who have
+deep, hands-on expertise in that specific area. Just people who know the
+technology and want to help you get the policy right.</p>
+
+<div class="briefing-contact">
+  <p><strong>hackersonthehill.org</strong> · <strong>@HillHackers</strong> · Run by <strong>I Am The Cavalry</strong> (iamthecavalry.org)</p>
+</div>
+
+<p class="briefing-cavalry-motto"><em>&ldquo;The Cavalry isn't coming. It falls to us. Safer. Sooner. Together.&rdquo;</em></p>
+
+<hr class="briefing-rule">
+
+<aside class="briefing-footnotes">
+  <p id="fn1"><sup>1</sup> I Am The Cavalry's "5 Ps" framework describes five core motivations of security
+  researchers: Protect, Puzzle, Prestige, Profit, and Patriotism. More at
+  iamthecavalry.org. <a href="#fnref1" aria-label="Back to content">&uarr;</a></p>
+</aside>
+
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Clean, print-optimized 2-pager for policymakers to understand what
Hackers on the Hill is, why they'd want to engage, and what next
steps look like. Includes dedicated layout, responsive CSS, and
print styles for PDF export. Added to Resources nav.

https://claude.ai/code/session_0156PPzWXvACTGkdp36dGtBw