### PR TITLE
Restructure briefing page for scannability and print

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1914,13 +1914,13 @@ button.location-card {
 }
 
 .briefing-section {
-  padding: 48px 0 64px;
+  padding: 40px 0;
 }
 
 .briefing-section h2 {
   font-size: 1.4rem;
   font-weight: 700;
-  margin-top: 40px;
+  margin-top: 0;
   margin-bottom: 16px;
   color: var(--text-primary);
 }
@@ -1932,52 +1932,125 @@ button.location-card {
   line-height: 1.7;
 }
 
+.briefing-bg-alt {
+  background-color: var(--bg-secondary);
+}
+
 .briefing-lede {
   font-size: 1.05rem;
   line-height: 1.75;
 }
 
-.briefing-impact-strip {
-  background: var(--bg-secondary);
-  border-left: 4px solid var(--accent-primary);
-  border-radius: 0 12px 12px 0;
-  padding: 20px 24px;
-  margin: 28px 0;
+/* Labeled bullet list */
+.briefing-bullets {
+  list-style: none;
+  padding-left: 0;
+  margin: 20px 0 24px;
 }
 
-.briefing-impact-strip .briefing-impact-label {
-  font-weight: 700;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent-primary);
-  margin-bottom: 6px;
-}
-
-.briefing-impact-strip p {
-  font-size: 0.95rem;
+.briefing-bullets li {
+  padding: 8px 0 8px 20px;
+  position: relative;
   line-height: 1.6;
-  margin-bottom: 0;
+}
+
+.briefing-bullets li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 16px;
+  width: 8px;
+  height: 8px;
+  background: var(--accent-primary);
+  border-radius: 50%;
+}
+
+/* Topic relevance chips */
+.briefing-topic-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 0;
+}
+
+.briefing-chip-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-right: 4px;
+}
+
+.briefing-chip {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--border-accent);
   color: var(--text-primary);
+  background: var(--bg-primary);
+  white-space: nowrap;
+}
+
+/* Stats grid */
+.briefing-stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 24px;
+  padding: 8px 0;
+}
+
+.briefing-stat {
+  text-align: center;
+}
+
+.briefing-stat-number {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--accent-primary);
+  line-height: 1.2;
+  margin-bottom: 4px;
+}
+
+.briefing-stat-label {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+/* Pull quote — full-width visual pause */
+.briefing-pullquote-section {
+  padding: 32px 0;
 }
 
 .briefing-pullquote {
+  border: none;
   border-left: 4px solid var(--accent-primary);
-  padding: 16px 24px;
-  margin: 28px 0;
+  padding: 8px 28px;
+  margin: 0;
   background: transparent;
 }
 
 .briefing-pullquote p {
-  font-size: 1.05rem;
+  font-size: 1.25rem;
   font-style: italic;
   color: var(--text-secondary);
   margin-bottom: 0;
-  line-height: 1.65;
+  line-height: 1.55;
 }
 
+/* Evidence intro line */
+.briefing-evidence-intro {
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
+/* Table */
 .briefing-table-wrap {
-  margin: 20px 0 32px;
+  margin: 0 0 8px;
   overflow-x: auto;
 }
 
@@ -2011,11 +2084,57 @@ button.location-card {
   border-bottom: none;
 }
 
+/* 3-step engagement CTA */
+.briefing-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 20px 0 24px;
+}
+
+.briefing-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.briefing-step-number {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--accent-primary);
+  color: var(--bright-white);
+  font-weight: 700;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.briefing-step-content {
+  font-size: 0.95rem;
+  line-height: 1.55;
+  padding-top: 6px;
+}
+
+/* Trust line */
+.briefing-trust-line {
+  text-align: center;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  margin: 8px 0 24px;
+}
+
+/* Contact card */
 .briefing-contact {
   background: var(--bg-secondary);
   border-radius: 12px;
   padding: 20px 24px;
-  margin: 28px 0 20px;
+  margin: 0 0 20px;
   text-align: center;
 }
 
@@ -2047,6 +2166,13 @@ button.location-card {
   margin-bottom: 0;
 }
 
+@media (max-width: 767px) {
+  .briefing-stats {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}
+
 @media (max-width: 575px) {
   .briefing-main {
     padding-top: 80px;
@@ -2061,17 +2187,23 @@ button.location-card {
   }
 
   .briefing-section {
-    padding: 32px 0 48px;
+    padding: 28px 0;
   }
 
-  .briefing-impact-strip {
-    padding: 16px 18px;
+  .briefing-pullquote p {
+    font-size: 1.05rem;
   }
 
   .briefing-table th,
   .briefing-table td {
     padding: 8px 10px;
     font-size: 0.82rem;
+  }
+
+  .briefing-step-number {
+    width: 30px;
+    height: 30px;
+    font-size: 0.9rem;
   }
 }
 
@@ -2108,82 +2240,120 @@ button.location-card {
 
   .briefing-hero {
     background: none;
-    padding: 0 0 8px;
+    padding: 0 0 6px;
     border-bottom: 3px solid #6b46a3;
-    margin-bottom: 16px;
+    margin-bottom: 10px;
   }
 
   .briefing-hero h1 {
-    font-size: 1.75rem;
+    font-size: 1.6rem;
     margin-bottom: 2px;
   }
 
   .briefing-tagline {
     color: #6b46a3;
-    font-size: 1rem;
+    font-size: 0.95rem;
   }
 
   .briefing-section {
-    padding: 0;
+    padding: 10px 0;
+  }
+
+  .briefing-bg-alt {
+    background: #f5f5f5;
   }
 
   .briefing-section h2 {
-    margin-top: 20px;
-    margin-bottom: 8px;
-    font-size: 1.15rem;
+    margin-top: 4px;
+    margin-bottom: 6px;
+    font-size: 1.05rem;
     color: #6b46a3;
   }
 
   .briefing-section p {
-    font-size: 0.85rem;
-    line-height: 1.5;
-    margin-bottom: 8px;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    margin-bottom: 6px;
   }
 
   .briefing-lede {
-    font-size: 0.9rem;
-    line-height: 1.55;
+    font-size: 0.85rem;
+    line-height: 1.5;
   }
 
-  .briefing-impact-strip {
-    border-left: 3px solid #6b46a3;
-    padding: 10px 14px;
-    margin: 12px 0;
-    background: #f5f5f5;
-    page-break-inside: avoid;
+  .briefing-bullets {
+    margin: 8px 0 10px;
   }
 
-  .briefing-impact-strip .briefing-impact-label {
-    color: #6b46a3;
-    font-size: 0.75rem;
-    margin-bottom: 4px;
-  }
-
-  .briefing-impact-strip p {
+  .briefing-bullets li {
+    padding: 3px 0 3px 16px;
     font-size: 0.8rem;
-    line-height: 1.45;
+    line-height: 1.4;
+  }
+
+  .briefing-bullets li::before {
+    width: 6px;
+    height: 6px;
+    top: 10px;
+    background: #6b46a3;
+  }
+
+  .briefing-topic-chips {
+    gap: 4px;
+    margin: 4px 0 0;
+  }
+
+  .briefing-chip-label {
+    font-size: 0.75rem;
+  }
+
+  .briefing-chip {
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-color: #ccc;
+  }
+
+  .briefing-stats {
+    gap: 12px;
+    padding: 4px 0;
+  }
+
+  .briefing-stat-number {
+    font-size: 1rem;
+    color: #6b46a3;
+  }
+
+  .briefing-stat-label {
+    font-size: 0.72rem;
+  }
+
+  .briefing-pullquote-section {
+    padding: 10px 0;
   }
 
   .briefing-pullquote {
     border-left: 3px solid #6b46a3;
-    padding: 8px 14px;
-    margin: 12px 0;
-    page-break-inside: avoid;
+    padding: 4px 16px;
   }
 
   .briefing-pullquote p {
-    font-size: 0.85rem;
+    font-size: 1rem;
     color: #555;
-    line-height: 1.5;
+    line-height: 1.4;
+  }
+
+  .briefing-evidence-intro {
+    font-size: 0.8rem;
+    margin-bottom: 6px;
   }
 
   .briefing-table-wrap {
-    margin: 10px 0 16px;
+    margin: 0 0 4px;
     page-break-inside: avoid;
   }
 
   .briefing-table {
-    font-size: 0.78rem;
+    font-size: 0.75rem;
   }
 
   .briefing-table thead {
@@ -2191,38 +2361,69 @@ button.location-card {
   }
 
   .briefing-table th {
-    padding: 6px 8px;
-    font-size: 0.78rem;
+    padding: 5px 8px;
+    font-size: 0.75rem;
   }
 
   .briefing-table td {
-    padding: 6px 8px;
+    padding: 5px 8px;
     border-bottom: 1px solid #ddd;
+  }
+
+  .briefing-steps {
+    gap: 8px;
+    margin: 8px 0 12px;
+  }
+
+  .briefing-step {
+    gap: 10px;
+  }
+
+  .briefing-step-number {
+    width: 24px;
+    height: 24px;
+    font-size: 0.75rem;
+    background: #6b46a3;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+
+  .briefing-step-content {
+    font-size: 0.8rem;
+    line-height: 1.4;
+    padding-top: 2px;
+  }
+
+  .briefing-trust-line {
+    font-size: 0.82rem;
+    margin: 4px 0 12px;
   }
 
   .briefing-contact {
     background: #f5f5f5;
-    padding: 12px 16px;
-    margin: 14px 0 10px;
+    padding: 10px 14px;
+    margin: 0 0 8px;
     page-break-inside: avoid;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .briefing-contact p {
-    font-size: 0.85rem;
+    font-size: 0.82rem;
   }
 
   .briefing-cavalry-motto {
-    font-size: 0.85rem;
+    font-size: 0.82rem;
     margin-bottom: 4px;
   }
 
   .briefing-rule {
-    margin: 12px 0 8px;
+    margin: 10px 0 6px;
   }
 
   .briefing-footnotes {
-    font-size: 0.72rem;
-    line-height: 1.4;
+    font-size: 0.68rem;
+    line-height: 1.35;
   }
 
   #footer {

--- a/briefing.md
+++ b/briefing.md
@@ -20,73 +20,113 @@ permalink: /briefing/
     <div class="row justify-content-center">
       <div class="col-12 col-lg-9">
 
-<p class="briefing-lede"><strong>Effective policy depends on foresight</strong> to understand emerging risks and
-opportunities before they arrive as crises. Your offices hear regularly from
-industry, academia, and think tanks, and each brings real value. Hackers on the
-Hill brings a voice that's harder to find: the early adopters who explore new
-technology firsthand, ask the questions others don't, and anticipate consequences
-(positive and negative) before they scale. No commercial agenda. No talking
-points. Just candid conversation.</p>
+<p class="briefing-lede"><strong>Your offices hear from industry, academia, and think tanks.</strong>
+Hackers on the Hill brings a voice that's harder to find: the people who explore
+new technology firsthand, spot risks early, and have no commercial agenda.</p>
 
-<p>Since 2017, Hackers on the Hill, an all-volunteer initiative, has been building
-trusted spaces where security researchers and policymakers work together on shared
-challenges. We forge relationships, hold events, and facilitate ongoing
-dialogue&nbsp;&mdash; grounded in shared values. No one gets paid. We just think policy works
-better when the people making it have candid conversations with the people
-living it.</p>
+<ul class="briefing-bullets">
+  <li><strong>Early signal</strong> &mdash; researchers working with technology before it scales, catching issues before they become crises</li>
+  <li><strong>Ground truth</strong> &mdash; real-world findings from the people who discovered remotely exploitable insulin pumps, vehicle braking flaws, and exposed water treatment systems</li>
+  <li><strong>No agenda</strong> &mdash; all-volunteer, no sales, no lobbying, no talking points</li>
+</ul>
 
-<div class="briefing-impact-strip">
-  <div class="briefing-impact-label">Since 2017</div>
-  <p>Events on Capitol Hill, at the White House, and in Ottawa, London, and
-  Colorado · Hundreds of researchers engaged · Dozens of policy briefings
-  delivered · Topics include AI, ransomware, critical infrastructure, medical
-  devices, IoT, encryption, supply chain security, and vulnerability
-  disclosure · <strong>Global since 2024</strong></p>
+<div class="briefing-topic-chips">
+  <span class="briefing-chip-label">Relevant to offices working on:</span>
+  <span class="briefing-chip">Healthcare</span>
+  <span class="briefing-chip">Critical Infrastructure</span>
+  <span class="briefing-chip">AI</span>
+  <span class="briefing-chip">Defense</span>
+  <span class="briefing-chip">Consumer Protection</span>
+  <span class="briefing-chip">Emergency Management</span>
 </div>
+
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section briefing-bg-alt">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
+
+<div class="briefing-stats">
+  <div class="briefing-stat">
+    <div class="briefing-stat-number">Since 2017</div>
+    <div class="briefing-stat-label">Building trusted researcher&ndash;policymaker relationships</div>
+  </div>
+  <div class="briefing-stat">
+    <div class="briefing-stat-number">Global since 2024</div>
+    <div class="briefing-stat-label">Capitol Hill, White House, Ottawa, London, Colorado</div>
+  </div>
+  <div class="briefing-stat">
+    <div class="briefing-stat-number">Hundreds</div>
+    <div class="briefing-stat-label">of researchers engaged across dozens of policy briefings</div>
+  </div>
+  <div class="briefing-stat">
+    <div class="briefing-stat-number">8+ topics</div>
+    <div class="briefing-stat-label">AI, ransomware, critical infrastructure, IoT, encryption, supply chain, medical devices, vulnerability disclosure</div>
+  </div>
+</div>
+
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
 
 <h2>Wait&hellip; Hackers?</h2>
 
-<p>The word carries baggage. But in the security community, a hacker is someone
-driven to understand how things work&nbsp;&mdash; and to make them work better. Think of the
-kid who took apart the family radio, the mechanic who challenges herself to
-diagnose an engine by sound, the engineer reporting cracks in the bridge their
-family drives across, or the tinkerer innovating novel uses for technology that
-aren't available on the market. Creativity, curiosity, dedication to a craft, and
-concern for others are cornerstones of <em>our</em> hacker community the same way they are
-of your local one.</p>
+<p><strong>In the security community, a hacker is someone driven to understand how things
+work&nbsp;&mdash; and to make them work better.</strong> Think of the engineer who reports cracks
+in the bridge their family drives across. Creativity, curiosity, and concern for
+others are cornerstones of this community.</p>
 
-<p>Academics study these problems, think tanks write about them, and industry sells.
-Hackers are driven to get their hands on technologies early and tend to spot
-issues and opportunities early&nbsp;&mdash; and prototype ways to address them. Hackers are
-leading indicators that give savvy policymakers a head start to shape technology
-toward the best outcomes for society.</p>
+<p>These are the people who found that insulin pumps could be remotely manipulated,
+that vehicle braking systems could be controlled through the entertainment
+console, and that water treatment systems were exposed to the open internet. In
+each case, they disclosed what they found in good faith so it could be fixed.</p>
 
-<blockquote class="briefing-pullquote">
-  <p>&ldquo;Effective policy is shaped by people who foresee consequences&nbsp;&mdash; positive and
-  negative&nbsp;&mdash; firsthand. Not through reports, but with direct evidence.&rdquo;</p>
-</blockquote>
+<p>Academics study these problems, think tanks write about them, and industry sells
+solutions. Hackers get their hands on technology early, spot issues early, and
+prototype fixes. They are leading indicators that give savvy policymakers a head
+start.<sup><a href="#fn1" id="fnref1">1</a></sup></p>
 
-<p>Security researchers are driven by a mix of motivations&nbsp;&mdash; protecting people,
-solving puzzles, professional pride, earning a living, or standing up for a
-cause.<sup><a href="#fn1" id="fnref1">1</a></sup> But the researchers who show up to engage with policymakers are
-overwhelmingly driven to <em>protect</em>&nbsp;&mdash; and they're giving their time to help you get
-it right. These are the people who found that insulin pumps could be remotely
-manipulated, that vehicle braking systems could be controlled through the
-entertainment console, and that water treatment systems were exposed to the open
-internet. In each case, they disclosed what they found in good faith so it could
-be fixed.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section briefing-pullquote-section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
+        <blockquote class="briefing-pullquote">
+          <p>&ldquo;Good policy is shaped by people who see consequences firsthand&nbsp;&mdash;
+          not just on paper.&rdquo;</p>
+        </blockquote>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section briefing-bg-alt">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
 
 <h2>Why this matters for your office</h2>
 
-<p>Effective cybersecurity policy requires understanding the technical reality on the
-ground&nbsp;&mdash; not just position papers and industry testimony. Security researchers see
-the actual attack surface. They know which systems are fragile, where the real
-risks are, and what's already being exploited. That's the kind of practical
-intelligence that makes the difference between legislation that looks good on
+<p><strong>Security researchers see the actual attack surface.</strong> They know which systems are
+fragile, where the real risks are, and what's already being exploited. That
+practical intelligence is the difference between legislation that looks good on
 paper and legislation that actually works.</p>
 
-<p>The security research community's engagement with policymakers has already
-contributed to real outcomes:</p>
+<p class="briefing-evidence-intro">This approach already works. Researcher&ndash;policymaker collaboration has shaped real policy outcomes:</p>
 
 <div class="briefing-table-wrap">
 <table class="briefing-table">
@@ -99,22 +139,22 @@ contributed to real outcomes:</p>
   </thead>
   <tbody>
     <tr>
-      <td>PATCH Act</td>
+      <td><strong>PATCH Act</strong></td>
       <td>US</td>
-      <td>Researcher findings on medical device flaws built the case for FDA cybersecurity authority</td>
+      <td>Findings on medical device flaws built the case for FDA cybersecurity authority</td>
     </tr>
     <tr>
-      <td>California SB-327</td>
+      <td><strong>California SB-327</strong></td>
       <td>California</td>
-      <td>Researcher demonstrations of IoT risks informed the first state law requiring connected device security</td>
+      <td>Demonstrations of IoT risks informed the first state law requiring connected device security</td>
     </tr>
     <tr>
-      <td>UK CoP &rarr; ETSI EN 303 645</td>
+      <td><strong>UK CoP &rarr; ETSI EN 303 645</strong></td>
       <td>UK / Global</td>
-      <td>Community input shaped a voluntary code that became the global baseline standard for IoT security</td>
+      <td>Community input shaped a voluntary code that became the global baseline for IoT security</td>
     </tr>
     <tr>
-      <td>National Cybersecurity Strategy</td>
+      <td><strong>National Cybersecurity Strategy</strong></td>
       <td>US</td>
       <td>Researchers joined White House working sessions shaping vulnerability disclosure policy</td>
     </tr>
@@ -122,17 +162,42 @@ contributed to real outcomes:</p>
 </table>
 </div>
 
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="briefing-section">
+  <div class="container">
+    <div class="row justify-content-center">
+      <div class="col-12 col-lg-9">
+
 <h2>Work with us</h2>
 
-<p>Hackers on the Hill isn't a one-day event&nbsp;&mdash; it's the start of a relationship.
-After each gathering, we facilitate follow-up conversations, technical reviews of
-draft legislation, and direct connections to subject-matter experts when your
-office needs them.</p>
+<p><strong>Hackers on the Hill isn't a one-day event&nbsp;&mdash; it's the start of a relationship.</strong></p>
 
-<p>If you're working on cybersecurity policy&nbsp;&mdash; healthcare, critical infrastructure,
-AI, defense, consumer protection&nbsp;&mdash; we can connect you with researchers who have
-deep, hands-on expertise in that specific area. Just people who know the
-technology and want to help you get the policy right.</p>
+<div class="briefing-steps">
+  <div class="briefing-step">
+    <div class="briefing-step-number">1</div>
+    <div class="briefing-step-content">
+      <strong>You share the issue</strong> &mdash; the topic, timing, and what your office needs
+    </div>
+  </div>
+  <div class="briefing-step">
+    <div class="briefing-step-number">2</div>
+    <div class="briefing-step-content">
+      <strong>We connect you</strong> &mdash; with researchers who have deep, hands-on expertise in that area
+    </div>
+  </div>
+  <div class="briefing-step">
+    <div class="briefing-step-number">3</div>
+    <div class="briefing-step-content">
+      <strong>We stay engaged</strong> &mdash; follow-up conversations, technical review of draft legislation, and ongoing access
+    </div>
+  </div>
+</div>
+
+<p class="briefing-trust-line">Not a trade association. Not a lobby. Not a vendor briefing.</p>
 
 <div class="briefing-contact">
   <p><strong>hackersonthehill.org</strong> · <strong>@HillHackers</strong> · Run by <strong>I Am The Cavalry</strong> (iamthecavalry.org)</p>
@@ -143,9 +208,10 @@ technology and want to help you get the policy right.</p>
 <hr class="briefing-rule">
 
 <aside class="briefing-footnotes">
-  <p id="fn1"><sup>1</sup> I Am The Cavalry's "5 Ps" framework describes five core motivations of security
-  researchers: Protect, Puzzle, Prestige, Profit, and Patriotism. More at
-  iamthecavalry.org. <a href="#fnref1" aria-label="Back to content">&uarr;</a></p>
+  <p id="fn1"><sup>1</sup> I Am The Cavalry's &ldquo;5 Ps&rdquo; framework describes five core motivations of
+  security researchers: Protect, Puzzle, Prestige, Profit, and Patriotism. The
+  researchers who show up to engage with policymakers are overwhelmingly driven to
+  <em>protect</em>. More at iamthecavalry.org. <a href="#fnref1" aria-label="Back to content">&uarr;</a></p>
 </aside>
 
       </div>


### PR DESCRIPTION
Rewrite content for three-layer reading depth (30s skim, 2-3min scan, full read). Compress opening into bold hook + labeled bullets. Replace paragraph-style impact block with bold stat grid. Tighten "Wait... Hackers?" by ~40%. Add topic relevance chips, 3-step CTA for "Work with us", and "Not a lobby" trust line. Pull quote now a full-width visual anchor between sections. Alternating section backgrounds for visual rhythm. Print styles updated for all new components.

https://claude.ai/code/session_0156PPzWXvACTGkdp36dGtBw