### PR TITLE
Add /sprint-plan skill and root CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash .claude/skills/sprint-plan/assets/env-probe.sh)",
+      "Bash(.claude/skills/sprint-plan/assets/env-probe.sh)"
+    ]
+  }
+}

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -27,56 +27,108 @@ immediate request.
 ## What makes a good sprint
 
 A sprint is a focused chunk of work with one clear goal and a clear
-finish line. The term comes from Scrum; the Scrum Guide
-(scrumguides.org) is the short, free, canonical source and is worth
-skimming once. No other skill in this repo teaches these principles —
-apply them explicitly.
+finish line. The idea comes from a software-planning method called
+Scrum; its canonical description lives at scrumguides.org and is short
+(around 14 pages) and free. No other skill in this repo teaches these
+principles, so apply them explicitly. The seven rules below are the
+ones that matter for a small volunteer-run site.
 
-1. **The site stays working, always.** Between any two commits —
-   including the ones inside a sprint — `main` should be deployable.
-   No half-finished event pages, no broken nav, no dangling links. If
-   a change can't ship on its own, break it into smaller steps that
-   can.
+### 1. The site never goes half-broken
 
-2. **One theme per sprint.** A sprint adds one event, *or* cleans up
-   the CSS, *or* improves accessibility — not all three. If the tasks
-   don't share an obvious one-sentence goal, it's probably two sprints
-   pretending to be one. Split it.
+Every commit should leave hackersonthehill.github.io in a state where
+you could hand the URL to a congressional staffer without blushing. No
+menu link pointing at a page that doesn't exist yet. No event card
+showing a date that was just deleted from the data file. No
+registration button that leads to a 404.
 
-3. **Decide what finished looks like before starting.** The
-   `## Definition of good` section in the plan is that list. Make it
-   specific and testable — "Netherlands 2026 page is live at
-   `/netherlands/`, linked from the nav and the homepage card,
-   registration button opens Eventbrite" — not aspirational ("site
-   feels modern"). If you can't write that list, you don't have a
-   sprint yet; go back to Phase 2.
+If a change has to land in stages — for example, building a new event
+page before linking to it from the homepage — plan the stages so every
+intermediate state is still safe to ship. Publish the page first,
+*then* link to it, not the other way around.
 
-4. **Order tasks so each one stands on its own.** If a sprint stops
-   halfway (the organizer disappears, the session runs out, the user
-   has to step away), the tasks that already shipped should still
-   deliver value. Put the highest-value, independently-useful tasks
-   first.
+### 2. One theme per sprint
 
-5. **Narrow beats broad.** Three tasks done well is a better sprint
-   than nine half-finished. When in doubt, move the last few items to
-   a follow-up — the "Out of scope" section exists for exactly this.
+A good sprint has a goal you can say in one sentence: *"Launch the
+Netherlands 2026 event page."* Not two sentences. Not *"and also."* If
+the plan covers launching an event AND refreshing the homepage AND
+fixing some accessibility issues, that's three sprints, not one — pick
+the most important and defer the rest.
 
-6. **If scope grows, split — don't stretch.** New work that surfaces
-   during execution goes into `docs/BACKLOG.md` or a new plan file,
-   not silently bolted onto the current sprint. Stretching is how
-   sprints quietly fail.
+### 3. Decide what "finished" looks like before you start
 
-7. **Finished means finished.** A task moves to `✅ Completed` only
-   when its verification step actually passes. "Mostly working, we'll
-   fix it later" is not finished — file a follow-up task and leave
-   the original open.
+Write it down in the plan's `## Definition of good` section as a
+checklist someone else could tick off by looking at the live site:
 
-**Where these apply in the workflow:**
+- *"A page for Netherlands 2026 exists at `/netherlands/`."*
+- *"A card for the event appears on the homepage events grid."*
+- *"The registration button opens the correct Eventbrite page in a
+  new tab."*
 
-- **Phase 3 (draft):** check items 2, 3, and 5 before writing the plan.
-  If any fail, loop back to Phase 2.
-- **Phase 4 (sign-off):** re-check items 1, 3, and 4 before accepting.
-- **Phase 5 (execute):** hold to items 1, 6, and 7 after each task.
+Avoid aspirational items like *"page feels modern"* or *"site is
+compelling"* — those aren't a finish line, they're opinions, and two
+people will disagree on whether they've been met. If you can't write a
+concrete checklist, the sprint isn't ready yet. Go back to Phase 2 and
+keep asking questions until you can.
+
+### 4. Order tasks so each one is worth shipping on its own
+
+Sprints get interrupted all the time: the organizer gets pulled into
+work, the Claude session runs out of room, someone has to travel.
+Don't save the most valuable work for the last task — do it first.
+
+Example order for a new event: publish the event page first, then add
+the homepage banner, then add the nice-to-haves (sponsor logos,
+speaker photo grid, etc.). If the sprint stops after the first task,
+the site is still better than it was. If you'd put the nice-to-haves
+first, stopping halfway would mean you spent time without giving
+visitors anything to click.
+
+### 5. Fewer, finished tasks beat many half-done ones
+
+Three tasks done well is a better sprint than nine tasks left in a
+messy state. If the plan feels long, move the less-essential items
+into the plan's "Out of scope" section. Those can become a second
+sprint later; they don't have to be done now to matter.
+
+### 6. When new work appears, write it down — don't quietly add it in
+
+Halfway through almost any sprint, you'll spot other things worth
+doing: *"while we're in here, we should also update the speaker
+photos."* Resist. Add those to `docs/BACKLOG.md` or a new plan file,
+and keep the current sprint focused on the goal it started with.
+Sprints that quietly grow tend to never end — the finish line keeps
+moving, and the original goal gets buried.
+
+### 7. "Finished" really means finished, not almost-finished
+
+A task gets marked `✅ Completed` only when its verification step
+*actually passes* — the page loads, the link works, the banner shows
+correctly on both phones and laptops, and anything else the task's
+verification section listed. Saying *"it's mostly working, we'll fix
+that last bit later"* and marking it done is the single most damaging
+habit on a small site, because those half-finished pieces accumulate
+silently and make the whole site feel sloppy over time.
+
+When you notice a small issue while finishing a task, write it down
+as a new task (either in this sprint or in `docs/BACKLOG.md`) and
+leave the original task open until the real thing genuinely works.
+A longer sprint with everything finished is always better than a
+shorter sprint with quiet loose ends.
+
+---
+
+**Where to apply these during the workflow:**
+
+- **When drafting the plan (Phase 3):** check rules 2, 3, and 5. If
+  any fails — the goal covers more than one theme, the "finished"
+  checklist is vague, or the task list is too long — loop back to
+  Phase 2 and ask more questions before writing the plan.
+- **At sign-off (Phase 4):** re-check rules 1, 3, and 4 before
+  accepting. Does the order of tasks make sense if the sprint gets
+  interrupted? Is every commit shippable?
+- **While executing (Phase 5):** hold to rules 1, 6, and 7 after
+  every task. Don't merge in unrelated work; don't mark half-finished
+  things as done.
 
 ---
 

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -77,11 +77,11 @@ work, the Claude session runs out of room, someone has to travel.
 Don't save the most valuable work for the last task — do it first.
 
 Example order for a new event: publish the event page first, then add
-the homepage banner, then add the nice-to-haves (sponsor logos,
-speaker photo grid, etc.). If the sprint stops after the first task,
-the site is still better than it was. If you'd put the nice-to-haves
-first, stopping halfway would mean you spent time without giving
-visitors anything to click.
+the homepage banner, then add the nice-to-haves (speaker photo grid,
+a link to last year's archive, venue map, etc.). If the sprint stops
+after the first task, the site is still better than it was. If you'd
+put the nice-to-haves first, stopping halfway would mean you spent
+time without giving visitors anything to click.
 
 ### 5. Fewer, finished tasks beat many half-done ones
 

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: sprint-plan
+description: Guided sprint-planning workflow for hackersonthehill.github.io. Use when the user wants to plan and execute a sprint — a new event page, a site-wide improvement, or a mix. Walks through archetype selection, environment probe, clarifying questions, plan draft, sign-off, then per-task execution with commit approval.
+---
+
+# /sprint-plan — Guided sprint planning
+
+This skill drives a five-phase flow: **archetype → environment probe →
+intake → draft → sign-off → execute**. Follow it in order. Do not skip
+phases; each one assumes the previous one ran.
+
+The supporting assets are:
+
+- `assets/intake-questions.md` — the question sets for each archetype.
+- `assets/sprint-template.md` — the structure to write the plan in.
+- `assets/env-probe.sh` — read-only environment detection.
+- `references/backlog-schema.md` — task-block schema used by
+  `docs/BACKLOG.md`; the plan must match it.
+
+Mission context (the *why* behind the site) lives in the repo root
+`CLAUDE.md` and in `briefing.md`. Read both before drafting — good
+sprint decisions serve the researcher↔policymaker mission, not just the
+immediate request.
+
+---
+
+## Phase 1 — Archetype
+
+**First action in every invocation.** Call `AskUserQuestion` with the
+three archetype options defined in `assets/intake-questions.md` (Phase 1).
+
+- **Content sprint** → use the Phase 2A question set. Most common path;
+  usually driven by a local event organizer.
+- **Infrastructure sprint** → use the Phase 2B question set.
+- **Mixed** → run 2A then 2B and split the plan in Phase 3.
+
+If the user's opening prompt already made the archetype obvious ("add
+a Netherlands 2026 page"), confirm your inference with a single
+`AskUserQuestion` rather than re-asking from scratch.
+
+---
+
+## Phase 1b — Environment probe
+
+**Run immediately after archetype selection, before any other questions.**
+
+Execute the probe:
+
+```
+bash .claude/skills/sprint-plan/assets/env-probe.sh
+```
+
+Parse `mode=`:
+
+- `mode=container` → full tooling assumed. Tell the user: *"Running in a
+  container — I can preview the site and run any checks I need."* Proceed.
+- `mode=host-docker` → host has Docker. Tell the user: *"I'll use
+  `docker-compose up` for previewing changes at http://localhost:4000."*
+  If `compose_file=no`, also say: *"Note: the repo references
+  `docker-compose.yml` in the README but I don't see one checked in. I
+  can scaffold a minimal one using the `jekyll/jekyll:latest` image
+  that `.github/copilot-instructions.md` recommends — want me to?"*
+- `mode=limited` → **warn explicitly** and use `AskUserQuestion` to
+  decide next step. Script:
+
+  > I can't find Docker or a container here. That means I can still edit
+  > Jekyll source files, but I won't be able to preview the site
+  > locally, run a build, or check links before Netlify deploys your
+  > branch. This usually happens when Claude Code is running on mobile
+  > or a restricted environment.
+  >
+  > Three options:
+  > 1. **Pause** so you can install Docker (or move to a machine with
+  >    it) and come back.
+  > 2. **Continue code-only** — I'll make edits, you'll verify by
+  >    looking at the Netlify branch preview after each push.
+  > 3. **Abort.**
+
+  Record the user's choice in the plan's `## Environment` section. Do
+  not assume any option; ask.
+
+**Do not attempt to install Docker, Ruby, or bundler** on the host. The
+fallback is explicit warning + user choice, never silent setup.
+
+---
+
+## Phase 2 — Intake & clarification
+
+Walk the user through the question set for their archetype from
+`assets/intake-questions.md`. Batch questions (max 4 per
+`AskUserQuestion` call). Skip anything already answered in the opening
+prompt — don't ask the user to repeat themselves.
+
+After each batch, summarize what you heard in plain prose before asking
+the next batch.
+
+When all questions are answered, play it all back in the format at the
+bottom of `assets/intake-questions.md` ("Here's what I heard …") and
+wait for confirmation or corrections before moving to Phase 3.
+
+---
+
+## Phase 3 — Research & draft
+
+Before drafting, explore the codebase to ground the plan in actual
+patterns and file paths. For content sprints, look at one existing
+event (e.g., `_data/events/colorado-2026.yml` + `colorado.md`) as a
+model. For infrastructure sprints, read the relevant files in
+`_layouts/` / `_includes/` / `assets/` first.
+
+For open-ended research across the repo, use the `Explore` subagent
+rather than many small `Grep`/`Read` calls.
+
+Draft the plan to `.claude/plans/<kebab-case-slug>.md` using
+`assets/sprint-template.md` as the structure and the task schema in
+`references/backlog-schema.md` for every `### Task N.M` block.
+
+Slug guidance: short, descriptive, kebab-case, no dates
+(e.g., `netherlands-2026-launch`, `css-modularize`,
+`newsletter-footer`). The existing reference in
+`docs/BACKLOG.md:15` uses two-word slugs — match that register.
+
+---
+
+## Phase 4 — Sign-off
+
+Present a brief summary of the plan (Goal, task count, environment, any
+caveats) and ask the user to approve.
+
+- If invoked from plan mode: call `ExitPlanMode` — that tool is the
+  sign-off.
+- If invoked mid-session (not in plan mode): call `AskUserQuestion`
+  with options **Approve / Revise / Abort**.
+
+On **Revise**, ask what to change and loop back to Phase 2 or Phase 3
+as appropriate. Preserve the plan file; update its `## Revision log`
+section with what changed.
+
+On **Approve**:
+1. Flip the plan's `**Status:**` metadata line from `Draft` to
+   `Approved`.
+2. Edit `docs/BACKLOG.md`: under the `## 🎯 CURRENT SPRINT` heading,
+   add a one-line link to the plan file. Do not re-sort or reformat
+   existing entries — minimal edit, additive only.
+3. Tell the user you're moving into execution.
+
+---
+
+## Phase 5 — Execute
+
+Use `TodoWrite` to mirror the plan's task list. Exactly one task
+`in_progress` at a time.
+
+For each task:
+
+1. Make the edits via `Edit` / `Write`.
+2. If `mode=container` or `mode=host-docker`: start `docker-compose up`
+   in the background and verify the affected page at
+   http://localhost:4000. Kill the server when you're done verifying.
+   If `mode=limited`: skip this step and note in the commit message
+   what the user should check on the Netlify branch preview.
+3. **Propose the commit — do not commit yet.** Show the staged file
+   list and a draft commit message. Call `AskUserQuestion` with
+   options **Commit / Amend message / Skip commit / Abort sprint**.
+4. On **Commit**: run `git add <specific files>` (never `git add -A`)
+   and `git commit`. Never use `--no-verify` or `--amend` to a
+   previously published commit.
+5. Update the task's `**Status:**` in the plan file to
+   `✅ Completed (YYYY-MM-DD)`.
+6. Move to the next task.
+
+If the user says **Skip commit** for a task, continue editing but keep
+the task open until a later commit covers it. If they say **Abort
+sprint**, stop execution, leave changes uncommitted, and tell them the
+plan file records where things stopped.
+
+---
+
+## Close-out
+
+When the last task is complete:
+
+1. Append a Revision History entry to the bottom of `docs/BACKLOG.md`
+   in the format shown at `references/backlog-schema.md` ("Close-out
+   entry for BACKLOG.md"). Match the 2026-01-12 entry's shape.
+2. Flip the plan's `**Status:**` to `Completed` and add a final line
+   to its `## Revision log`.
+3. Remind the user: *"Push when you're ready — I've left that step to
+   you."* Do not push without explicit instruction.
+
+---
+
+## What this skill does not do
+
+- Does not install Docker, Ruby, or bundler. Warn + ask instead.
+- Does not commit without approval. Every commit is a user decision.
+- Does not push. The user pushes when they're ready.
+- Does not skip pre-commit hooks. If a hook fails, investigate the
+  root cause and fix it, then make a new commit.
+- Does not duplicate `.github/copilot-instructions.md`. Follow those
+  conventions; don't restate them in the plan.
+- Does not invent new abstractions or frameworks. Reuse existing
+  patterns from `_layouts/` and `assets/css/main.css`.

--- a/.claude/skills/sprint-plan/SKILL.md
+++ b/.claude/skills/sprint-plan/SKILL.md
@@ -24,6 +24,62 @@ immediate request.
 
 ---
 
+## What makes a good sprint
+
+A sprint is a focused chunk of work with one clear goal and a clear
+finish line. The term comes from Scrum; the Scrum Guide
+(scrumguides.org) is the short, free, canonical source and is worth
+skimming once. No other skill in this repo teaches these principles —
+apply them explicitly.
+
+1. **The site stays working, always.** Between any two commits —
+   including the ones inside a sprint — `main` should be deployable.
+   No half-finished event pages, no broken nav, no dangling links. If
+   a change can't ship on its own, break it into smaller steps that
+   can.
+
+2. **One theme per sprint.** A sprint adds one event, *or* cleans up
+   the CSS, *or* improves accessibility — not all three. If the tasks
+   don't share an obvious one-sentence goal, it's probably two sprints
+   pretending to be one. Split it.
+
+3. **Decide what finished looks like before starting.** The
+   `## Definition of good` section in the plan is that list. Make it
+   specific and testable — "Netherlands 2026 page is live at
+   `/netherlands/`, linked from the nav and the homepage card,
+   registration button opens Eventbrite" — not aspirational ("site
+   feels modern"). If you can't write that list, you don't have a
+   sprint yet; go back to Phase 2.
+
+4. **Order tasks so each one stands on its own.** If a sprint stops
+   halfway (the organizer disappears, the session runs out, the user
+   has to step away), the tasks that already shipped should still
+   deliver value. Put the highest-value, independently-useful tasks
+   first.
+
+5. **Narrow beats broad.** Three tasks done well is a better sprint
+   than nine half-finished. When in doubt, move the last few items to
+   a follow-up — the "Out of scope" section exists for exactly this.
+
+6. **If scope grows, split — don't stretch.** New work that surfaces
+   during execution goes into `docs/BACKLOG.md` or a new plan file,
+   not silently bolted onto the current sprint. Stretching is how
+   sprints quietly fail.
+
+7. **Finished means finished.** A task moves to `✅ Completed` only
+   when its verification step actually passes. "Mostly working, we'll
+   fix it later" is not finished — file a follow-up task and leave
+   the original open.
+
+**Where these apply in the workflow:**
+
+- **Phase 3 (draft):** check items 2, 3, and 5 before writing the plan.
+  If any fail, loop back to Phase 2.
+- **Phase 4 (sign-off):** re-check items 1, 3, and 4 before accepting.
+- **Phase 5 (execute):** hold to items 1, 6, and 7 after each task.
+
+---
+
 ## Phase 1 — Archetype
 
 **First action in every invocation.** Call `AskUserQuestion` with the

--- a/.claude/skills/sprint-plan/assets/env-probe.sh
+++ b/.claude/skills/sprint-plan/assets/env-probe.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# env-probe.sh — read-only environment probe for the /sprint-plan skill.
+#
+# Purpose: tell Claude which dev/testing capabilities are available so it can
+# pick the right workflow (container → host-docker → limited).
+#
+# Does NOT modify anything. Safe to run repeatedly. Outputs key=value lines
+# on stdout so Claude can parse it deterministically.
+
+set -u
+
+mode="unknown"
+in_container="no"
+host_docker="no"
+compose_file="no"
+compose_cmd=""
+cwd_writable="no"
+ruby_present="no"
+bundler_present="no"
+dns_ok="no"
+
+if [ -f /.dockerenv ]; then
+  in_container="yes"
+fi
+if [ -r /proc/1/cgroup ] && grep -qE '(docker|containerd|kubepods|podman)' /proc/1/cgroup 2>/dev/null; then
+  in_container="yes"
+fi
+
+if [ "$in_container" = "yes" ]; then
+  mode="container"
+fi
+
+if command -v docker >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    host_docker="yes"
+    if [ "$mode" = "unknown" ]; then
+      mode="host-docker"
+    fi
+  fi
+fi
+
+if command -v docker-compose >/dev/null 2>&1; then
+  compose_cmd="docker-compose"
+elif docker compose version >/dev/null 2>&1; then
+  compose_cmd="docker compose"
+fi
+
+if [ -f docker-compose.yml ] || [ -f docker-compose.yaml ] || [ -f compose.yml ] || [ -f compose.yaml ]; then
+  compose_file="yes"
+fi
+
+if [ -w . ]; then
+  cwd_writable="yes"
+fi
+
+if command -v ruby >/dev/null 2>&1; then
+  ruby_present="yes"
+fi
+if command -v bundle >/dev/null 2>&1; then
+  bundler_present="yes"
+fi
+
+if command -v getent >/dev/null 2>&1 && getent hosts github.com >/dev/null 2>&1; then
+  dns_ok="yes"
+fi
+
+if [ "$mode" = "unknown" ]; then
+  mode="limited"
+fi
+
+printf 'mode=%s\n' "$mode"
+printf 'in_container=%s\n' "$in_container"
+printf 'host_docker=%s\n' "$host_docker"
+printf 'compose_cmd=%s\n' "$compose_cmd"
+printf 'compose_file=%s\n' "$compose_file"
+printf 'cwd_writable=%s\n' "$cwd_writable"
+printf 'ruby_present=%s\n' "$ruby_present"
+printf 'bundler_present=%s\n' "$bundler_present"
+printf 'dns_ok=%s\n' "$dns_ok"

--- a/.claude/skills/sprint-plan/assets/intake-questions.md
+++ b/.claude/skills/sprint-plan/assets/intake-questions.md
@@ -1,0 +1,97 @@
+# Intake questions
+
+Canonical clarifying questions the `/sprint-plan` skill asks. Group into
+at most four questions per `AskUserQuestion` call (tool limit). Skip any
+question the user has already answered in their opening prompt.
+
+Summarize what you've heard back to the user after each set of questions
+before moving to the next phase.
+
+---
+
+## Phase 1 — Archetype (always first)
+
+**Q: What kind of sprint is this?**
+- **Content sprint** — adding or updating an event page (date, location,
+  speakers, copy, banner, archive). Usually led by a local event organizer.
+- **Infrastructure sprint** — site-wide changes (layouts, CSS, JS, data
+  model, analytics, build). Usually led by the maintainer.
+- **Mixed / not sure** — some of both, or the user isn't sure yet.
+
+The answer determines which question set below you use, which files the
+plan will touch, and which template you draft from.
+
+---
+
+## Phase 2A — Content-sprint questions
+
+Ask in plain language. Do not assume the user knows Jekyll, front matter,
+or Liquid. If they don't know an answer, note it as "TBD" in the plan
+rather than blocking on it.
+
+1. **Which location and year?** (e.g., "Colorado 2026", "Netherlands 2026")
+   — drives `event_key`, the `.md` filename, and the archive branch name.
+2. **Event date, venue, and registration URL?** Any of these can be TBD.
+3. **Short description + any speakers or partners to highlight?** Roughly
+   one paragraph for the event hero; full agenda can come later.
+4. **What visibility surfaces does this need?**
+   - Banner at the top of the homepage? (y/n + launch date)
+   - Info-bar entry on the homepage? (y/n)
+   - Nav / menu entry? (y/n)
+   - A card in the Events grid? (y/n)
+5. **Existing archive to link?** — e.g., last year's event on the same
+   site, or a brand-new location with nothing to link yet.
+6. **Hard deadline and owner?** — launch-by date (for the page going
+   live) and who signs off on final content.
+
+---
+
+## Phase 2B — Infrastructure-sprint questions
+
+1. **Goal in one sentence.** What should be different after this sprint?
+2. **Why now?** What problem does this solve, and what's the cost of
+   waiting? (Helps prioritize and scope.)
+3. **What does "good" look like?** Measurable criteria where possible —
+   Lighthouse score, WCAG level, specific user task that should succeed,
+   page weight target, etc.
+4. **Scope boundaries.** What's explicitly IN, and what's explicitly OUT
+   of this sprint? The out-of-scope list is as important as the in-scope
+   list.
+5. **Hard constraints.**
+   - Launch-by date (event tie-in?)
+   - Accessibility floor (WCAG AA is the project baseline)
+   - SEO / analytics constraints (don't break GTM, don't regress
+     structured data)
+   - Motion / reduced-motion budget
+   - Zero-new-dependency policy? (default: yes, per copilot-instructions)
+6. **Audience impact.** Which pages or regions does this affect? Any
+   pages that should be explicitly left alone?
+7. **Dependencies.** Anything waiting on a person (content owner, legal
+   review, analytics lead) or a third party (Netlify, GTM, a vendor)?
+
+---
+
+## Phase 2C — Mixed sprint
+
+Run Phase 2A and Phase 2B in sequence, but explicitly tell the user
+you're going to do that so they know what to expect. In the plan,
+split the task list into a "Content" section and an "Infrastructure"
+section so each side can be reviewed independently.
+
+---
+
+## Playback
+
+Before moving to Phase 3 (research and draft), play back to the user:
+
+> Here's what I heard:
+> - Goal: …
+> - Definition of good: …
+> - In scope: …
+> - Out of scope: …
+> - Deadline: …
+> - Environment for dev/test: … *(from Phase 1b probe)*
+>
+> Anything I missed or got wrong?
+
+Wait for confirmation (or corrections) before drafting the plan.

--- a/.claude/skills/sprint-plan/assets/sprint-template.md
+++ b/.claude/skills/sprint-plan/assets/sprint-template.md
@@ -1,0 +1,119 @@
+# Sprint plan template
+
+Copy this file to `.claude/plans/<kebab-case-slug>.md` when drafting a new
+sprint. The header format mirrors `docs/BACKLOG.md` so plans can be linked
+under `🎯 CURRENT SPRINT` without reformatting.
+
+When filling this in: delete the instructional italics in parentheses, keep
+the section headings as-is, and use the existing BACKLOG task schema
+(`## Task N.M`) for every task.
+
+---
+
+# Sprint: <Title>
+
+**Archetype:** Content | Infrastructure | Mixed
+**Status:** Draft | Approved | Active | Completed
+**Created:** YYYY-MM-DD
+**Owner:** <name or role>
+**Launch-by:** YYYY-MM-DD | none
+
+## Goal
+
+*(One or two sentences. What should be different after this sprint?)*
+
+## Why this matters
+
+*(One or two sentences tying back to the mission — researcher↔policymaker
+bridge, a specific upcoming event, an accessibility or SEO gap, etc.
+Helps future readers and Claude make trade-offs that serve the mission.)*
+
+## Definition of good
+
+*(Measurable criteria. For content sprints: page live at /<region>/, nav
+entry present, banner launches on agreed date, registration link works.
+For infrastructure sprints: Lighthouse score, WCAG level, specific task
+flow, page weight, etc.)*
+
+- [ ] …
+- [ ] …
+
+## Scope
+
+**In scope:**
+- …
+
+**Out of scope (explicitly deferred):**
+- …
+
+## Environment
+
+*(Auto-filled from the Phase 1b probe. Pick one.)*
+
+- `container` — running in an unconstrained container; `docker-compose up`
+  works; full preview + test available.
+- `host-docker` — host has Docker; will use `docker-compose up` for
+  preview. *(Note if `docker-compose.yml` needs scaffolding.)*
+- `limited` — no container, no Docker (e.g., mobile / web Claude Code).
+  Code edits only; previewing and link-checking will be skipped. The user
+  accepted this trade-off during Phase 1b.
+
+## Tasks
+
+### Task 1.1: <Title>
+**Priority:** High | Medium | Low
+**Effort:** <minutes | hours>
+**Status:** Todo
+**Files:** `path/to/file.ext`
+
+**Description:**
+*(What changes and why in one short paragraph.)*
+
+**Implementation:**
+*(Steps, commands, or code snippets. Keep snippets minimal — actual edits
+happen via Edit/Write during execution. Reference existing patterns
+instead of inventing new ones.)*
+
+**Verification:**
+- …
+- If env is `container` or `host-docker`: `docker-compose up` →
+  http://localhost:4000 → confirm the affected page/section.
+- If env is `limited`: note what can't be verified locally and what the
+  user should check after Netlify deploys the branch preview.
+
+### Task 1.2: <Title>
+*(same schema)*
+
+## Testing checklist
+
+*(Keep for infrastructure sprints. For content-only sprints, keep the
+parts that apply — e.g., mobile viewport, light/dark theme, keyboard nav.)*
+
+**Automated / in-browser:**
+- [ ] Multiple viewports (mobile / tablet / desktop)
+- [ ] Lighthouse pass on affected pages (if infra)
+- [ ] GTM Preview if analytics touched
+
+**Manual:**
+- [ ] Keyboard tab order through new/changed UI
+- [ ] Light and dark themes
+- [ ] `prefers-reduced-motion` respected if animation touched
+- [ ] Color contrast check (WebAIM) if colors touched
+
+## Rollback
+
+*(One or two sentences: which commit to revert, or which file(s) to
+restore. For content sprints with a new branch: delete the branch.)*
+
+## Sign-off
+
+- [ ] Plan reviewed and approved by <owner>
+- [ ] Environment trade-offs understood
+- [ ] Ready to execute
+
+## Revision log
+
+- YYYY-MM-DD — Plan drafted.
+- YYYY-MM-DD — Revision N: <what changed>.
+- YYYY-MM-DD — Completed. See `docs/BACKLOG.md` Revision History for the
+  session summary.

--- a/.claude/skills/sprint-plan/references/backlog-schema.md
+++ b/.claude/skills/sprint-plan/references/backlog-schema.md
@@ -1,0 +1,95 @@
+# BACKLOG task schema (reference)
+
+`docs/BACKLOG.md` uses a consistent task schema across every sprint. The
+`/sprint-plan` skill must write new plans in this same schema so they can
+be linked from BACKLOG without reformatting and read by anyone already
+familiar with the repo's planning conventions.
+
+## Canonical task block
+
+```markdown
+### Task N.M: <Title> [status emoji]
+**Priority:** High | Medium | Low
+**Effort:** <minutes | hours>
+**Status:** Todo | In Progress | ✅ Completed (YYYY-MM-DD) | ⏸ Deferred
+**Files:** `path/to/file.ext`, `path/to/other.ext`
+
+**Description:**
+<1–3 sentences: what this task does and why it matters.>
+
+**Implementation:**
+<Steps, commands, or code snippets. Keep snippets short — they're
+illustrative, not the final edit. Reference existing patterns rather
+than inventing new ones.>
+
+**Verification:**
+- <How to confirm the change works, in specific terms.>
+- <Include the `docker-compose up` step when env supports it.>
+- <Include any accessibility / light-dark / reduced-motion check that
+   applies.>
+```
+
+Real examples to model on (from `docs/BACKLOG.md`):
+
+- Simple / small task — Task 1.1 "Add GTM Preconnect Hint"
+  (`docs/BACKLOG.md:21-39`). 5-minute effort, single file, one-line code
+  snippet, two verification bullets.
+- Visual / UI task — Task 2.1 "Consolidate Coming Soon Cards"
+  (`docs/BACKLOG.md:66-122`). 30-minute effort, HTML snippets for
+  before/after, explicit visual verification across light/dark themes.
+- Accessibility / a11y task — Task 4.2 "Add Banner On-Load Animation"
+  (`docs/BACKLOG.md:125-172`). Includes explicit
+  `prefers-reduced-motion` handling and multi-theme check.
+
+## Sprint-level structure
+
+A full plan in `.claude/plans/<slug>.md` has these sections, in order:
+
+1. `# Sprint: <Title>` — H1 with the sprint name.
+2. Metadata block (Archetype, Status, Created, Owner, Launch-by).
+3. `## Goal` — 1–2 sentences.
+4. `## Why this matters` — mission tie-in, 1–2 sentences.
+5. `## Definition of good` — checklist of measurable criteria.
+6. `## Scope` — explicit In / Out lists.
+7. `## Environment` — container / host-docker / limited, with any caveats.
+8. `## Tasks` — one `### Task N.M` block per task, using the schema above.
+9. `## Testing checklist` — scoped to the sprint's surface area.
+10. `## Rollback` — one or two sentences.
+11. `## Sign-off` — checklist the user ticks before execution.
+12. `## Revision log` — dated entries as the plan evolves.
+
+## Status emojis used in BACKLOG.md
+
+- `✅` — completed
+- `📋` — approved / next up
+- `🎯` — current sprint
+- `📝` — deferred / future
+- `🔧` — testing checklist
+- `📚` — reference links
+- `🔄` — revision history
+
+Reuse these; don't invent new emoji sets. Keep the use of emoji minimal —
+BACKLOG.md uses them as section markers, not inline decoration.
+
+## Close-out entry for BACKLOG.md
+
+When a sprint completes, append an entry to the Revision History section
+at the bottom of `docs/BACKLOG.md` (matching the 2026-01-12 entry at
+`docs/BACKLOG.md:1542`):
+
+```markdown
+- **YYYY-MM-DD (Session Complete):** <Sprint title> — <N> of <M> tasks completed.
+  - **Session Summary:**
+    - Total implementation time: ~<X>
+    - Files modified: <N> (<brief list>)
+    - <Any regressions / caveats.>
+  - **Completed Tasks:**
+    - ✅ Task N.M: <Title>
+    - …
+  - **Deferred:**
+    - 📝 Task N.M: <Title> — <reason>
+  - **Key Improvements Delivered:**
+    - …
+  - **Next Session Recommendations:**
+    1. …
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,39 @@ of past work (PATCH Act, California SB-327, ETSI EN 303 645), and a
 recruitment touchpoint for researchers. Favor clarity and trust over
 cleverness or polish.
 
+## Who edits this repo
+
+The people making changes here are mostly volunteers — security
+researchers and local event organizers — not professional web
+developers or engineers. Some are comfortable with git and Markdown;
+most are not comfortable with Liquid templates, CSS specificity,
+Jekyll build internals, or software-planning jargon. A few may be
+editing their first website.
+
+Write for that audience:
+
+- **Plans, commit messages, and explanations** in plain English. Spell
+  out technical terms on first use in a session (e.g., "the front
+  matter — the block of key/value lines between `---` markers at the
+  top of the file").
+- **Don't assume familiarity with software jargon.** Phrases like
+  "definition of done," "scope creep," or "regression" will slide
+  past most people here unnoticed. Describe the thing directly instead
+  ("what finished looks like", "new work being quietly added", "a
+  change that breaks something that used to work").
+- **"I don't know" is a prompt to explain, not a blocker.** If a user
+  doesn't know what `_data/events/*.yml` is or what "the nav" means,
+  offer a short answer and keep going. Default to a sensible guess
+  rather than bouncing the question back.
+- **Code comments only when a non-developer reader would benefit** —
+  otherwise they're noise that someone will eventually have to re-read
+  and wonder about.
+
+The `/sprint-plan` skill exists partly for this reason: to let a
+volunteer who's never touched Jekyll still ship a polished event page
+safely, with Claude walking them through the choices in everyday
+language.
+
 ## Two kinds of change
 
 Most edits here are one of two shapes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo. Short on purpose — read
+`.github/copilot-instructions.md` for detailed style / CSS / JS
+conventions, and `briefing.md` for the full mission context.
+
+## What this site is for
+
+Hackers on the Hill connects security researchers directly with
+policymakers so legislation is shaped by people who see real-world
+consequences firsthand. Running since 2017 (global since 2024: DC,
+Ottawa, London, Colorado, Netherlands), it's an all-volunteer initiative
+of I Am The Cavalry — non-commercial, no lobbying, no vendor pitches.
+Tagline: *Technical Truth Meets Policy Power.*
+
+This is important context when making judgment calls. The site is a
+low-friction introduction for congressional and parliamentary offices, an
+announcement and registration hub for upcoming events, a credible archive
+of past work (PATCH Act, California SB-327, ETSI EN 303 645), and a
+recruitment touchpoint for researchers. Favor clarity and trust over
+cleverness or polish.
+
+## Two kinds of change
+
+Most edits here are one of two shapes:
+
+- **Content** — adding or updating an event (date, location, speakers,
+  banner, archive). Usually driven by a local event organizer who owns
+  the content but isn't a web developer. Touches `_data/events/*.yml`,
+  region `.md` files, `_data/pages/index.yml`, `_data/banners.yml`,
+  `_data/archives.yml`, and `archives/`.
+- **Infrastructure** — site-wide structure, layouts, CSS, JS, data
+  model, analytics, build. Usually driven by the maintainer. Touches
+  `_layouts/`, `_includes/`, `assets/`, `_config.yml`, `docs/`,
+  `.github/`.
+
+The `/sprint-plan` skill asks which one applies up front, then walks
+the user through a tailored intake, drafts a plan, waits for sign-off,
+and executes with per-commit approval. Use it whenever the user wants
+to plan and execute a sprint. Plans land in `.claude/plans/` and are
+linked from `docs/BACKLOG.md`.
+
+## Dev environment
+
+Preferred: `docker-compose up` → http://localhost:4000 (Jekyll image).
+Never install Ruby locally. If Docker isn't available (e.g., mobile /
+web Claude Code), the sprint-plan skill surfaces that explicitly and
+asks how the user wants to proceed — don't silently skip preview steps.
+
+## Commit policy
+
+Propose each commit and wait for approval. Don't auto-commit, don't use
+`--no-verify`, don't amend published commits, and don't push without
+being asked.
+
+## Tone for any copy you draft
+
+Match `briefing.md`: plain-language, evidence-led, no vendor-speak, no
+hype. The Cavalry motto — *"The Cavalry isn't coming. It falls to us.
+Safer. Sooner. Together."* — sets the register.
+
+## Don't
+
+- Don't duplicate `.github/copilot-instructions.md` here; point to it.
+- Don't introduce new frameworks, build tooling, or npm packages.
+- Don't remove `CNAME`.
+- Don't edit `assets/vendor/` unless explicitly upgrading a vendor lib.


### PR DESCRIPTION
Introduces a guided sprint-planning workflow for the site: Claude asks
up front whether a change is content (event page) or infrastructure
(site-wide), probes the dev environment (container / host-docker /
limited) and warns when preview isn't possible, walks through tailored
clarifying questions, drafts a plan in the existing BACKLOG schema,
waits for sign-off, then executes task-by-task with per-commit approval.

Scaffolding only — no existing files modified beyond the new CLAUDE.md.
Plan files land in `.claude/plans/` and are linked from
`docs/BACKLOG.md` when a sprint is approved.