### PR TITLE
Add registration links and fix hero logos

### DIFF
--- a/_data/events/2026-nl.yml
+++ b/_data/events/2026-nl.yml
@@ -23,6 +23,7 @@ hero: # Hero section content for the event page
   date_label: "May 8, 2026" # Hero date line
   location_label: Den Haag, Nederland # Hero location line
   logo: /assets/img/hath-nl-2026_lightmode.svg # Hero logo image (replace when logo is available)
+  logo_dark: /assets/img/hath-nl-2026_darkmode.svg
   logo_alt: Hackers at the Hof logo # Hero logo alt text
   description: Eerlijke, Technische beleidsdiscussies tussen cybersecurity onderzoekers en beleidsambtenaren in Nederland. # Hero description
   cta: # Primary call-to-action button

--- a/_data/events/2026-us.yml
+++ b/_data/events/2026-us.yml
@@ -23,6 +23,7 @@ hero:
   date_label: June 16, 2026
   location_label: Washington, DC
   logo: /assets/img/hoth-us_lightmode.svg
+  logo_dark: /assets/img/hoth-us_darkmode.svg
   logo_alt: Hackers on the Hill United States logo
   description: Cybersecurity researchers and Congressional staff, in the same room, making policy smarter together.
   cta:

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -29,20 +29,18 @@ layout: base
               <p><strong>{{ event.hero.notice }}</strong></p>
               {% endif %}
               {% if event.hero.cta %}
-              <div class="d-flex flex-wrap gap-2">
               {% if event.hero.cta.modal_target %}
-              <button type="button" class="button priority" data-bs-toggle="modal" data-bs-target="{{ event.hero.cta.modal_target }}">{{ event.hero.cta.label }}</button>
+              <button type="button" class="button priority me-2 mb-2" data-bs-toggle="modal" data-bs-target="{{ event.hero.cta.modal_target }}">{{ event.hero.cta.label }}</button>
               {% else %}
-              <a class="button priority" href="{{ event.hero.cta.url }}"{% if event.hero.cta.external %} target="_blank" rel="noopener"{% endif %}>{{ event.hero.cta.label }}</a>
+              <a class="button priority me-2 mb-2" href="{{ event.hero.cta.url }}"{% if event.hero.cta.external %} target="_blank" rel="noopener"{% endif %}>{{ event.hero.cta.label }}</a>
               {% endif %}
               {% if event.hero.cta_secondary %}
               {% if event.hero.cta_secondary.modal_target %}
-              <button type="button" class="button" data-bs-toggle="modal" data-bs-target="{{ event.hero.cta_secondary.modal_target }}">{{ event.hero.cta_secondary.label }}</button>
+              <button type="button" class="button mb-2" data-bs-toggle="modal" data-bs-target="{{ event.hero.cta_secondary.modal_target }}">{{ event.hero.cta_secondary.label }}</button>
               {% else %}
-              <a class="button" href="{{ event.hero.cta_secondary.url }}"{% if event.hero.cta_secondary.external %} target="_blank" rel="noopener"{% endif %}>{{ event.hero.cta_secondary.label }}</a>
+              <a class="button mb-2" href="{{ event.hero.cta_secondary.url }}"{% if event.hero.cta_secondary.external %} target="_blank" rel="noopener"{% endif %}>{{ event.hero.cta_secondary.label }}</a>
               {% endif %}
               {% endif %}
-              </div>
               {% endif %}
             </div>
           </div>

--- a/cyber-policy-shark-tank.md
+++ b/cyber-policy-shark-tank.md
@@ -10,6 +10,7 @@ permalink: /cyber-policy-shark-tank/
       <div class="col-12 col-lg-9">
         <h1>Cyber Policy Shark Tank</h1>
         <p class="briefing-tagline">Pitch your policy idea. Defend it to the people who can make it happen.</p>
+        <a class="button priority mt-3" href="https://forms.gle/NVQcZ376SutUUWeB7" target="_blank" rel="noopener">Sign up for DC 2026</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Opens registration for US 2026: main session signup and Cyber Policy Shark Tank signup links added throughout the site
- Adds a second CTA button to the event hero (new `cta_secondary` field in event yml, supported by updated `event.html` layout)
- Updates the Cyber Policy Shark Tank page hero with a signup button and replaces the newsletter modal link with the live form link
- Fixes dark mode hero logos for US 2026 and Netherlands (both were missing `logo_dark` in the hero section, causing the light-ink SVG to show on a dark background)

## Test plan

- [ ] US 2026 event page (`/us-2026/`) shows two hero buttons: **Register** and **Cyber Policy Shark Tank**, both linking to the correct Google Forms
- [ ] Cyber Policy Shark Tank page (`/cyber-policy-shark-tank/`) shows a **Sign up for DC 2026** button in the hero
- [ ] US 2026 hero logo looks correct in light mode (dark ink) and dark mode (light ink)
- [ ] Netherlands hero logo looks correct in light mode and dark mode
- [ ] Colorado hero unaffected
- [ ] Other event pages unaffected

https://claude.ai/code/session_01VP4MTHS6YBm34TUQgUr3Y2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VP4MTHS6YBm34TUQgUr3Y2)_