### PR TITLE
Fix blank page for users with prefers-reduced-motion enabled

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6,6 +6,13 @@
 * License: MIT
 */
 
+/* Safety net: AOS sets [data-aos] to opacity:0 at paint time and only
+   reveals content once AOS.init() runs. If AOS never initializes, content
+   would stay invisible. Allow the hidden state only after AOS has taken
+   ownership of a node (indicated by the aos-init class it adds). */
+[data-aos] { opacity: 1; }
+.aos-init[data-aos] { opacity: 0; }
+
 :root {
   /* ============================================================================
      1.1 Color Palette

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,12 +11,13 @@
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
     // Page-load animation
-    if (window.AOS && !prefersReducedMotion.matches) {
+    if (window.AOS) {
       AOS.init({
         duration: 800,
         easing: 'ease-in-out',
         once: true,
-        mirror: false
+        mirror: false,
+        disable: prefersReducedMotion.matches
       });
     }
 


### PR DESCRIPTION
AOS sets [data-aos] elements to opacity:0 at paint time and only reveals them once AOS.init() runs. The previous code skipped init entirely when reduced-motion was on, leaving <main> invisible since it carries data-aos.

Fix: always call AOS.init(), passing disable:true when reduced-motion is on so AOS strips the attribute itself. Also adds a CSS safety net so a failed/missing AOS script can never strand content at opacity:0.

Diagnosed by Rob Fuller (Mubix).

https://claude.ai/code/session_01VP4MTHS6YBm34TUQgUr3Y2